### PR TITLE
[Solve] : 1189 (컴백홈) , 13335 (트럭)

### DIFF
--- a/JJangDongHyeon/BOJ/1189/sol.py
+++ b/JJangDongHyeon/BOJ/1189/sol.py
@@ -1,0 +1,47 @@
+import sys
+
+sys.stdin = open('input.txt')
+#델타 탐색
+dxy = [(0,1),(0,-1),(1,0),(-1,0)]
+def dfs(start_x, start_y, max_distance, way_count):
+    global count
+
+    #방문 처리
+    visited[start_x][start_y] = 1
+
+    # 도착 지점 + 딱 맞는 횟수인짗 ㅔ크
+    if (start_x == 0 and start_y == max_garo - 1) and (way_count == max_distance):
+        count += 1
+        return
+    for dx, dy in dxy:
+        next_y = start_y + dy
+        next_x = start_x + dx
+
+        # 리스트 범위 체크
+        if not(0 <= next_y < max_garo and 0 <= next_x < max_sero) : continue
+
+        # 벽체크
+        if map[next_x][next_y] == 'T' : continue
+
+        #카운트 넘는지 체크
+        if way_count + 1 > max_distance: continue
+
+        #방문 체크
+        if visited[next_x][next_y] : continue
+
+        # 갈 수 있으면 탐색
+        dfs(next_x, next_y, max_distance, way_count + 1)
+
+        # 갔다 왔으면 방문처리 다시 취소
+        visited[next_x][next_y] = 0
+
+
+
+max_sero, max_garo, max_distance = map(int, input().split())
+visited = [[0] * max_garo for _ in range(max_sero)]
+
+map = [input() for _ in range(max_sero)]
+count = 0
+
+dfs(max_sero - 1, 0, max_distance, 1)
+print(count)

--- a/JJangDongHyeon/BOJ/13335/sol.py
+++ b/JJangDongHyeon/BOJ/13335/sol.py
@@ -1,0 +1,49 @@
+import sys
+from collections import deque
+sys.stdin = open('input.txt')
+
+
+truck_num, bridge_length, bridge_max_weight = map(int, input().split())
+trucks = deque(map(int, input().split()))
+
+current_bridge = deque([0] * bridge_length)
+
+# 현재 다리위에 있는 트럭들의 무게 합인데, 맨 처음 sum(current_bridge) 하면 너무 오래걸릴까봐... 바꿈
+current_bridge_weight_sum = 0
+
+
+time = 0
+# print(trucks)
+# print(current_bridge)
+
+
+# 현재 다리의 상태가 빌때까지 반복문
+while current_bridge:
+    time += 1
+
+    # 만약 트럭이 없다면 현재 다리(데큐)만 남아 있는 거니까 무한 루프 돌 일이 없음.
+    current_bridge_weight_sum -= current_bridge.popleft()
+
+    #아직 다리를 지나가지 않은 트럭이 있다면
+    if trucks:
+        # if sum(current_bridge) + trucks[0] <= bridge_max_weight:
+
+        #현재 다리 위에 있는 무게 + 트럭 리스트에 있는 맨 처음 무게의 합을 보고
+        if current_bridge_weight_sum + trucks[0] <= bridge_max_weight:
+
+            # 맨 앞의 트럭을 빼서
+            truck = trucks.popleft()
+
+            # 현재 다리에 트럭을 넣는다.
+            current_bridge.append(truck)
+
+            # 그리고 현재 다리 무게의 합에다가 금방 빼낸 트럭의 무게를 더함
+            current_bridge_weight_sum += truck
+
+
+        # 맨 앞의 트럭의 무게 + 현재 다리위에 있는 무게의 합이 한계보다 초과하면 24번 줄에서 현재 다리 데큐를 popleft만 해버려서 다리의 길이가 달라짐, 그래서 0을 하나 넣어줘서 크기를 맞춤
+        else:
+            current_bridge.append(0)
+
+
+print(time)


### PR DESCRIPTION
### 문제 설명
- 문제 : [Solve] : 1189 (컴백홈) , 13335 (트럭)
- 플랫폼: 백준 / 프로그래머스 / SWEA 등
- 난이도 : 둘 다 실버1
- 시간 : 잘 모르겠음
- 메모리 : 32412KB, 34908KB

### 코드
```
import sys

sys.stdin = open('input.txt')
#델타 탐색
dxy = [(0,1),(0,-1),(1,0),(-1,0)]
def dfs(start_x, start_y, max_distance, way_count):
    global count

    #방문 처리
    visited[start_x][start_y] = 1

    # 도착 지점 + 딱 맞는 횟수인짗 ㅔ크
    if (start_x == 0 and start_y == max_garo - 1) and (way_count == max_distance):
        count += 1
        return
    for dx, dy in dxy:
        next_y = start_y + dy
        next_x = start_x + dx

        # 리스트 범위 체크
        if not(0 <= next_y < max_garo and 0 <= next_x < max_sero) : continue

        # 벽체크
        if map[next_x][next_y] == 'T' : continue

        #카운트 넘는지 체크
        if way_count + 1 > max_distance: continue

        #방문 체크
        if visited[next_x][next_y] : continue

        # 갈 수 있으면 탐색
        dfs(next_x, next_y, max_distance, way_count + 1)

        # 갔다 왔으면 방문처리 다시 취소
        visited[next_x][next_y] = 0



max_sero, max_garo, max_distance = map(int, input().split())
visited = [[0] * max_garo for _ in range(max_sero)]

map = [input() for _ in range(max_sero)]
count = 0

dfs(max_sero - 1, 0, max_distance, 1)
print(count)


---

import sys
from collections import deque
sys.stdin = open('input.txt')


truck_num, bridge_length, bridge_max_weight = map(int, input().split())
trucks = deque(map(int, input().split()))

current_bridge = deque([0] * bridge_length)

# 현재 다리위에 있는 트럭들의 무게 합인데, 맨 처음 sum(current_bridge) 하면 너무 오래걸릴까봐... 바꿈
current_bridge_weight_sum = 0


time = 0
# print(trucks)
# print(current_bridge)


# 현재 다리의 상태가 빌때까지 반복문
while current_bridge:
    time += 1

    # 만약 트럭이 없다면 현재 다리(데큐)만 남아 있는 거니까 무한 루프 돌 일이 없음.
    current_bridge_weight_sum -= current_bridge.popleft()

    #아직 다리를 지나가지 않은 트럭이 있다면
    if trucks:
        # if sum(current_bridge) + trucks[0] <= bridge_max_weight:

        #현재 다리 위에 있는 무게 + 트럭 리스트에 있는 맨 처음 무게의 합을 보고
        if current_bridge_weight_sum + trucks[0] <= bridge_max_weight:

            # 맨 앞의 트럭을 빼서
            truck = trucks.popleft()

            # 현재 다리에 트럭을 넣는다.
            current_bridge.append(truck)

            # 그리고 현재 다리 무게의 합에다가 금방 빼낸 트럭의 무게를 더함
            current_bridge_weight_sum += truck


        # 맨 앞의 트럭의 무게 + 현재 다리위에 있는 무게의 합이 한계보다 초과하면 24번 줄에서 현재 다리 데큐를 popleft만 해버려서 다리의 길이가 달라짐, 그래서 0을 하나 넣어줘서 크기를 맞춤
        else:
            current_bridge.append(0)


print(time)
```


### 풀이 방식
1. dfs 탐색하면서 왔던곳 다시 방문 풀기
2. 데큐로 하나씩 넣고 popleft로 순서 앞으로 옮김
---
* PR 제목은 커밋 메시지와 통일합니다.