### PR TITLE
[Solve] : [BOJ] 20055 컨베이어 벨트 위의 로봇 - 문제 해결

### DIFF
--- a/minwoo/BOJ/20055/sol.py
+++ b/minwoo/BOJ/20055/sol.py
@@ -1,0 +1,41 @@
+import sys
+from collections import deque
+sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+
+def run_conv():
+    global conv, N, K
+    time = 1
+    robot = deque([0] * N)
+    while True:
+        # 1. 벨트가 로봇과 함께 한 칸 회전
+        conv.rotate(1)
+        robot.pop()
+        robot.appendleft(0)
+        robot[-1] = 0
+        # 2. 가장 먼저 벨트에 올라간 로봇부터(끝까지 이동한 로봇은 내림)(N-2부터 -1까지)
+        for i in range(N-2, -1, -1):
+            if robot[i] == 0: continue
+            # 이동하려는 칸의 내구도가 0이거나, 로봇이 있다면 pass
+            if conv[i + 1] == 0 or robot[i + 1] == 1:
+                continue
+            robot[i] = 0
+            conv[i+1] -= 1
+            # i+1 값이 N-1이라면 로봇은 컨베이어에서 내린다.
+            # 내리면 갱신하지 않는다.
+            if i+1 != N-1:
+                robot[i+1] = 1
+        # 3. 올리는 위치 내구도가 0이 아니라면 로봇을 올림
+        if conv[0] != 0:
+            robot[0] = 1
+            conv[0] -= 1
+        # 4. 내구도가 0인 칸을 확인
+        if conv.count(0) >= K:
+            return time
+        time += 1
+
+
+N, K = map(int, input().split())
+conv = deque(list(map(int, input().split())))
+print(run_conv())


### PR DESCRIPTION
### 문제 설명
- 문제 : [BOJ 20055 컨베이어 벨트 위의 로봇](https://www.acmicpc.net/problem/20055)
- 플랫폼: 백준
- 난이도 : 골드 5
- 시간 : Python 1600 ms / C++  ms
- 메모리 : Python 34952 KB / C++  KB

### 코드
<details>
<summary>Python</summary>

```py
import sys
from collections import deque
input = sys.stdin.readline


def run_conv():
    global conv, N, K
    time = 1
    robot = deque([0] * N)
    while True:
        # 1. 벨트가 로봇과 함께 한 칸 회전
        conv.rotate(1)
        robot.pop()
        robot.appendleft(0)
        robot[-1] = 0
        # 2. 가장 먼저 벨트에 올라간 로봇부터(끝까지 이동한 로봇은 내림)(N-2부터 -1까지)
        for i in range(N-2, -1, -1):
            if robot[i] == 0: continue
            # 이동하려는 칸의 내구도가 0이거나, 로봇이 있다면 pass
            if conv[i + 1] == 0 or robot[i + 1] == 1:
                continue
            robot[i] = 0
            conv[i+1] -= 1
            # i+1 값이 N-1이라면 로봇은 컨베이어에서 내린다.
            # 내리면 갱신하지 않는다.
            if i+1 != N-1:
                robot[i+1] = 1
        # 3. 올리는 위치 내구도가 0이 아니라면 로봇을 올림
        if conv[0] != 0:
            robot[0] = 1
            conv[0] -= 1
        # 4. 내구도가 0인 칸을 확인
        if conv.count(0) >= K:
            return time
        time += 1


N, K = map(int, input().split())
conv = deque(list(map(int, input().split())))
print(run_conv())
```

</details>

<details>
<summary>C++(준비중)</summary>

```cpp
// 준비중
```

</details>

### 풀이 방식
- 3번 예제에서 틀려서 확인하는 과정을 진행
    - 컨베이어가 회전해서 N자리에 있던 로봇은 자동적으로 배출되는데, N-1에 있던 로봇이 N으로 위치했을 때 로봇을 제거하지 못해 정답이 나오지 않았습니다.
    - 로봇 회전시키고 N자리에 위치한 로봇도 같이 제거했습니다.
- 그 이외는 문제에 나와있는 시퀀스대로 진행했습니다.

---
* PR 제목은 커밋 메시지와 통일합니다.