### PR TITLE
[Solved] : BOJ/16928 뱀과 사다리 게임

### DIFF
--- a/Comet/BOJ/16928/sol.cpp
+++ b/Comet/BOJ/16928/sol.cpp
@@ -1,0 +1,52 @@
+using namespace std;
+#include <iostream>
+#include <vector>
+#include <queue>
+const int target = 100;
+
+int result = 0;
+int map[101] = { 0 };
+int events[101] = { 0 };
+bool visited[101] = { 0 };
+int ladder, snake, l, s, cur, len;
+queue<int> que;
+void solve() {
+	cin >> ladder >> snake;
+	for (int i = 0; i < ladder + snake; i++) {
+		cin >> l >> s;
+		events[l] = s;
+	}
+	visited[1] = 1;
+	que.push(1);
+	while (true)
+	{
+		result++;
+		len = que.size();
+		for (int i = 0; i < len; i++) {
+			cur = que.front(); que.pop();
+			for (int j = 1; j <= 6; j++) {
+				if (cur + j == 100) {
+					return;
+				}
+				else if (cur + j < 100 && !visited[cur + j]) {
+					if (events[cur + j]) {
+						que.push(events[cur + j]);
+						visited[cur + j] = 1; visited[events[cur + j]] = 1;
+					}
+					else
+					{
+						que.push(cur + j);
+						visited[cur + j] = 1;
+					}
+				}
+			}
+		}
+	}
+	return;
+}
+
+int main() {
+	solve();
+	cout << result << '\n';
+	return 0;
+}


### PR DESCRIPTION
### 문제 설명

- 문제 : [뱀과 사다리 게임](https://www.acmicpc.net/problem/16928)
- 플랫폼: 백준 / 프로그래머스 / SWEA 등
- 난이도 : 골드 5
- 시간 : 0ms
- 메모리 : 2024kb

### 코드

```
using namespace std;
#include <iostream>
#include <vector>
#include <queue>
const int target = 100;

int result = 0;
int map[101] = { 0 };
int events[101] = { 0 };
bool visited[101] = { 0 };
int ladder, snake, l, s, cur, len;
queue<int> que;
void solve() {
	cin >> ladder >> snake;
	for (int i = 0; i < ladder + snake; i++) {
		cin >> l >> s;
		events[l] = s;
	}
	visited[1] = 1;
	que.push(1);
	while (true)
	{
		result++;
		len = que.size();
		for (int i = 0; i < len; i++) {
			cur = que.front(); que.pop();
			for (int j = 1; j <= 6; j++) {
				if (cur + j == 100) {
					return;
				}
				else if (cur + j < 100 && !visited[cur + j]) {
					if (events[cur + j]) {
						que.push(events[cur + j]);
						visited[cur + j] = 1; visited[events[cur + j]] = 1;
					}
					else
					{
						que.push(cur + j);
						visited[cur + j] = 1;
					}
				}
			}
		}
	}
	return;
}

int main() {
	solve();
	cout << result << '\n';
	return 0;
}
```

### 풀이 방식
*  0~ 100 배열 만듦, visited, events. events 는 사다리 혹은 뱀 정보를 저장하는 배열.
* 주사위 1~6 으로 bfs 돌림.
* visited 1 처리 빼먹어서 메모리 오류 자꾸 떳삼... 머쓱타드.
* while 1번 돌 때마다  queue 길이 체크해서 그 길이만큼 돌림.
* 이러면 que의 같은 거리의 데이터를 한꺼번에 넣고 한꺼번에 뺄 수 있음. (que에 거리요소를 함께 집어 넣을 필요가 없음)
---

- PR 제목은 커밋 메시지와 통일합니다.
