### PR TITLE
[Solve] : [BOJ] 16928 뱀과 사다리 게임 - 문제 해결

### DIFF
--- a/minwoo/BOJ/16928/sol.py
+++ b/minwoo/BOJ/16928/sol.py
@@ -1,0 +1,53 @@
+import sys
+from collections import deque
+sys.stdin = open("input.txt", "r")
+
+"""
+주사위를 사용, 주사위의 각 면에는 1부터 6까지 수가 하나씩 적혀있다.
+게임은 크기가 10 * 10
+총 100개의 칸으로 나누어져 있는 보드판에서 진행
+
+플레이어는 주사위를 굴려 나온 수 만큼 이동해야 한다
+1. 플레이어가 i 칸에 있고 주사위 수가 4라면 i+4번 칸으로 이동해야 한다
+2. 만약 주사위를 굴린 결과가 100번 칸을 넘어갔다면, 이동할 수 없다.
+3. 도착한 칸이 사다리라면, 사다리를 타고 위로 올라간다.
+
+뱀이 있는 칸에 도착하면, 뱀ㄴ을 따라서 내려가게 된다.
+즉 사다리를 이용해 이동한 칸의 번호는 원래 있던 칸의 번호보다 크고, 
+뱀을 이용해 이동한 칸의 번호는 원래 있던 칸의 번호보다 작아진다
+
+결론
+사다리를 최대한 이용할 수 있는 위치로만 이동할 수 있어야 한다.
+"""
+
+
+def bfs():
+    global data
+    q = deque([(1, 0)])
+    visited = [0] * 109
+    visited[1] = 1
+    while q:
+        # print(q)
+        n, c = q.popleft()
+        if n == 100:
+            return c
+        c += 1
+        for i in range(1, 7):
+            if data[(acc := n + i)] != 0:
+                q.append((data[acc], c))
+                visited[data[acc]] = 1
+                continue
+            if visited[acc] == 1:
+                continue
+            if acc > 100:
+                continue
+            q.append((acc, c))
+            visited[acc] = 1
+
+
+N, M = map(int, input().split())
+data = [0] * 109
+for _ in range(N+M):
+    a, b = map(int, input().split())
+    data[a] = b
+print(bfs())


### PR DESCRIPTION
### 문제 설명

- 문제 : [BOJ 16928 뱀과 사다리 게임](https://www.acmicpc.net/problem/16928)
- 플랫폼: 백준
- 난이도 : Gold 5
- 시간 : 56 ms
- 메모리 : 34944 KB

### 코드

```
from collections import deque


def bfs():
    global data
    q = deque([(1, 0)])
    visited = [0] * 109
    visited[1] = 1
    while q:
        n, c = q.popleft()
        if n == 100:
            return c
        c += 1
        for i in range(1, 7):
            if data[(acc := n + i)] != 0:
                q.append((data[acc], c))
                visited[data[acc]] = 1
                continue
            if visited[acc] == 1:
                continue
            if acc > 100:
                continue
            q.append((acc, c))
            visited[acc] = 1


N, M = map(int, input().split())
data = [0] * 109
for _ in range(N+M):
    a, b = map(int, input().split())
    data[a] = b
print(bfs())
```

### 풀이 방식
- visited는 여유있게 109개 놓습니다.
- 2가지 경우인데, data(지도, 뱀, 사다리 유무 관계 없이 해당 칸으로 왔을 때 이동하는 칸의 값을 가지고 있음, 사다리나 뱀이 아닐 경우 값은 0)를 방문했을 때 값이 0이 아닐 경우는 사다리와 뱀으로 이동하는 경우이므로 queue에 삽입합니다
    - 이때 뱀을 타고 내려가서 이동하는 경우 100에 도달할 수 있는 사다리가 바로 옆에 있는 경우가 있을 수 있으므로 뱀을 무시하지 않습니다.
- 그 다음은 일반적으로 주사위 수만큼만 이동해서 위치하는 경우입니다.
    - 이때는 BFS와 마찬가지로, 방문 유무와, acc(주사위 값을 + 한 경우)값이 100을 초과하는 경우 데이터를 추가하지 않습니다.
---

- PR 제목은 커밋 메시지와 통일합니다.
