### PR TITLE
[Solve] :인구이동 문제 해결

### DIFF
--- a/JJangDongHyeon/BOJ/16234/sol.py
+++ b/JJangDongHyeon/BOJ/16234/sol.py
@@ -1,0 +1,58 @@
+import sys
+sys.stdin = open('input.txt')
+
+from collections import deque
+
+def bfs(x,y, visited):
+    que = deque([(x,y)])
+
+    visited[x][y] = 1
+    union = [(x,y)]
+    union_total_sum = board[x][y]
+    while que:
+        x, y = que.popleft()
+
+        for dx , dy in dxy:
+            next_x, next_y = dx + x, dy + y
+
+            if not(0 <= next_x < N and 0 <= next_y < N): continue
+            if visited[next_x][next_y]: continue
+            neighbor_minus = abs(board[x][y] - board[next_x][next_y])
+            if L <= neighbor_minus <= R:
+                que.append((next_x, next_y))
+                visited[next_x][next_y] = 1
+                union.append((next_x,next_y))
+                union_total_sum += board[next_x][next_y]
+
+    if len(union) != 1:
+        new_population = union_total_sum // len(union)
+        for union_x, union_y in union:
+            board[union_x][union_y] = new_population
+        return True
+
+    return False
+
+
+
+dxy = [(1, 0),(-1,0),(0,-1),(0,1)]
+N, L, R = map(int, input().split())
+#두 나라의 인구 차이가 L명 이상, R명 이하라면,
+
+board = [list(map(int, input().split())) for _ in range(N)]
+day_count = 0
+
+while True:
+
+    visited = [[0] * N for _ in range(N)]
+    possible_move = False
+    for i in range(N):
+        for j in range(N):
+            if not visited[i][j]:
+                if bfs(i,j, visited):
+                    possible_move = True
+
+    if not possible_move:
+        break
+    day_count += 1
+
+print(day_count)


### PR DESCRIPTION
### 문제 설명

- 문제 : 인구이동 
- 플랫폼: 백준 
- 난이도 : 골드 4
- 시간 : 4940ms
- 메모리 : 35016kb

### 코드

```
import sys
sys.stdin = open('input.txt')

from collections import deque

def bfs(x,y, visited):
    que = deque([(x,y)])

    visited[x][y] = 1
    union = [(x,y)]
    union_total_sum = board[x][y]
    while que:
        x, y = que.popleft()

        for dx , dy in dxy:
            next_x, next_y = dx + x, dy + y

            if not(0 <= next_x < N and 0 <= next_y < N): continue
            if visited[next_x][next_y]: continue
            neighbor_minus = abs(board[x][y] - board[next_x][next_y])
            if L <= neighbor_minus <= R:
                que.append((next_x, next_y))
                visited[next_x][next_y] = 1
                union.append((next_x,next_y))
                union_total_sum += board[next_x][next_y]

    if len(union) != 1:
        new_population = union_total_sum // len(union)
        for union_x, union_y in union:
            board[union_x][union_y] = new_population
        return True

    return False



dxy = [(1, 0),(-1,0),(0,-1),(0,1)]
N, L, R = map(int, input().split())
#두 나라의 인구 차이가 L명 이상, R명 이하라면,

board = [list(map(int, input().split())) for _ in range(N)]
day_count = 0

while True:

    visited = [[0] * N for _ in range(N)]
    possible_move = False
    for i in range(N):
        for j in range(N):
            if not visited[i][j]:
                if bfs(i,j, visited):
                    possible_move = True

    if not possible_move:
        break
    day_count += 1

print(day_count)

```

### 풀이 방식

---
1. 일단 맨 처음 board를 0,0부터 n-1,n-1 까지의 좌표를 전부 체크해서 방문하지 않았다면(연합에 없다면), bfs를 돌립니다.
2. bfs를 돌려서 내 주변 이웃들과 연합을 맺을 수 있는지(인구 이동이 가능한지) 판별 해서 연합 리스트에 넣고 que가 끝날때 까지 전부 더함!!!
3. que가 끝나며 연합 리스트에 넣은 좌표들을 통해 수학적 계산 + 그 좌표의 값을 바꾸기
4. 만약 bfs를 돌렸는데 내 주변 이웃과 연합을 맺을 수 없다면 FALSE를 리턴해주고, 
5. 함수 바깥 while문 > 2중포문에서 나머지 board를 돌면서 계쏙 반복,
6. 더 이상 연합을 맺을 수 없을 때 까지 시뮬레이션을 돌림!     
- PR 제목은 커밋 메시지와 통일합니다.
