### PR TITLE
[Solve] :경쟁적 전염 문제 해결

### DIFF
--- a/JJangDongHyeon/BOJ/18405/sol.py
+++ b/JJangDongHyeon/BOJ/18405/sol.py
@@ -1,0 +1,48 @@
+import sys
+sys.stdin = open('input.txt')
+
+from collections import deque
+
+
+dxy = [(0,1), (0,-1), (1,0), (-1,0)]
+
+def find_virus():
+
+    virus_coor = []
+    for i in range(N):
+        for j in range(N):
+            if board[i][j] != 0:
+                virus_coor.append((board[i][j], i, j, 0))
+    virus_coor.sort()
+    return deque(virus_coor)
+
+def spread_virus(virus_coor):
+
+    while virus_coor:
+        virus_number, x, y, time = virus_coor.popleft()
+
+        if time >= S:
+            continue
+
+        for dx, dy in dxy:
+            next_x, next_y = dx + x, dy + y
+            if not(0 <= next_x < N and 0 <= next_y < N): continue
+            if board[next_x][next_y] != 0: continue
+            board[next_x][next_y] = virus_number
+            virus_coor.append((virus_number, next_x, next_y, time + 1))
+
+N, K = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(N)]
+
+S, result_x, result_y = map(int, input().split())
+
+
+
+
+virus_coor = find_virus()
+
+if len(virus_coor) > 0 :
+    spread_virus(virus_coor)
+
+
+print(board[result_x - 1][result_y - 1])


### PR DESCRIPTION
### 문제 설명

- 문제 : 경쟁적 전염
- 플랫폼: 백준
- 난이도 : 골드5
- 시간 : 96ms
- 메모리 : 34976kb

### 코드

```
import sys
sys.stdin = open('input.txt')

from collections import deque


dxy = [(0,1), (0,-1), (1,0), (-1,0)]

def find_virus():

    virus_coor = []
    for i in range(N):
        for j in range(N):
            if board[i][j] != 0:
                virus_coor.append((board[i][j], i, j, 0))
    virus_coor.sort()
    return deque(virus_coor)

def spread_virus(virus_coor):

    while virus_coor:
        virus_number, x, y, time = virus_coor.popleft()

        if time >= S:
            continue

        for dx, dy in dxy:
            next_x, next_y = dx + x, dy + y
            if not(0 <= next_x < N and 0 <= next_y < N): continue
            if board[next_x][next_y] != 0: continue
            board[next_x][next_y] = virus_number
            virus_coor.append((virus_number, next_x, next_y, time + 1))

N, K = map(int, input().split())
board = [list(map(int, input().split())) for _ in range(N)]

S, result_x, result_y = map(int, input().split())




virus_coor = find_virus()

if len(virus_coor) > 0 :
    spread_virus(virus_coor)


print(board[result_x - 1][result_y - 1])
```

### 풀이 방식

---
1. 처음 2중 for문을 돌아 각 바이러스들의 number와 좌표, 타임0 을 담은 튜플을 담은 리스트를 바이러스 number로 정렬 후 > deque에 담아서 넘겨요.
2. 그리고 bfs를 돌려서 popleft()로 하나씩 꺼낸 후 time(S)를 안넘긴다면 바이러스를 전염 시켜요.
- PR 제목은 커밋 메시지와 통일합니다.
