### PR TITLE
[Solve] :치킨 배달 문제 해결

### DIFF
--- a/JJangDongHyeon/BOJ/15686/sol.py
+++ b/JJangDongHyeon/BOJ/15686/sol.py
@@ -1,0 +1,45 @@
+import sys
+from collections import deque
+sys.stdin = open('input.txt')
+def bfs(selected):
+    global home_coor
+    distance_sum = 0
+
+    for start_x, start_y in home_coor:
+        min_dist = 99999999
+        for selected_x, selected_y in selected:
+            distance = abs(selected_x - start_x) + abs(selected_y - start_y)
+            min_dist = min(min_dist, distance)
+        distance_sum += min_dist
+
+    return distance_sum
+
+
+
+
+def combination(start, selected):
+
+    if len(selected) == limit_store:
+        global min_distance
+        distance_sum = bfs(selected)
+        min_distance = min(distance_sum, min_distance)
+    for i in range(start, len(store_coor)):
+        combination(i + 1, selected + [store_coor[i]])
+
+dxy = [(0,1),(0,-1),(1,0),(-1,0)]
+
+N, limit_store = map(int, input().split())
+
+board = [list(map(int, input().split())) for _ in range(N)]
+store_coor = []
+home_coor = []
+min_distance = 99999999
+for i in range(N):
+    for j in range(N):
+        if board[i][j] == 2:
+            store_coor.append((i,j))
+        if board[i][j] == 1:
+            home_coor.append((i,j))
+combination(0, [])
+
+print(min_distance)


### PR DESCRIPTION
### 문제 설명

- 문제 : 치킨 배달
- 플랫폼: 백준
- 난이도 : 골드5
- 시간 : 212ms
- 메모리 : 34968kb

### 코드

```
import sys
from collections import deque
sys.stdin = open('input.txt')
def bfs(selected):
    global home_coor
    distance_sum = 0

    for start_x, start_y in home_coor:
        min_dist = 99999999
        for selected_x, selected_y in selected:
            distance = abs(selected_x - start_x) + abs(selected_y - start_y)
            min_dist = min(min_dist, distance)
        distance_sum += min_dist

    return distance_sum




def combination(start, selected):

    if len(selected) == limit_store:
        global min_distance
        distance_sum = bfs(selected)
        min_distance = min(distance_sum, min_distance)
    for i in range(start, len(store_coor)):
        combination(i + 1, selected + [store_coor[i]])

dxy = [(0,1),(0,-1),(1,0),(-1,0)]

N, limit_store = map(int, input().split())

board = [list(map(int, input().split())) for _ in range(N)]
store_coor = []
home_coor = []
min_distance = 99999999
for i in range(N):
    for j in range(N):
        if board[i][j] == 2:
            store_coor.append((i,j))
        if board[i][j] == 1:
            home_coor.append((i,j))
combination(0, [])

print(min_distance)
```

### 풀이 방식

---
1. 지도에서 1과 2인 좌표를 따로 모읍니다.
2. 2(치킨가게)를 M의 갯수로 채우는 조합을 돌려요.
3. M의 개수를 채우면 1의 좌표를 모은 리스트와 2의 좌표를 모은 리스트를 2중 반복문을 돌려서 최소 거리만 계산해줘요.
---
거리 계산하는 함수가 bfs인 이유는 맨 처음에 각 좌표를 하나씩 bfs 를 돌릴 생각을 했었는데... 그럴 필요가 없었네요 하하 굿;'
- PR 제목은 커밋 메시지와 통일합니다.
