### PR TITLE
[Solve] : [BOJ] 15903 카드 합체 놀이 - 문제 해결

### DIFF
--- a/minwoo/BOJ/15903/sol.cpp
+++ b/minwoo/BOJ/15903/sol.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <queue>
+using namespace std;
+
+int main() {
+	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	FILE* fp;
+	freopen_s(&fp, "input.txt", "r", stdin);
+
+	int N, M;
+	priority_queue<long long int, vector<long long int>, greater<long long int>> pq;
+
+	cin >> N >> M;
+	int num;
+	for (int i = 0; i < N; i++) {
+		cin >> num;
+		pq.push(num);
+	}
+	for (int i = 0; i < M; i++) {
+		long long int x = pq.top(); 
+		pq.pop();
+		long long int y = pq.top(); 
+		pq.pop();
+		pq.push(x+y); pq.push(x+y);
+	}
+	int result = 0;
+	while (!pq.empty()) {
+		result += pq.top();
+		pq.pop();
+	}
+	cout << result << "\n";
+	return 0;
+}

--- a/minwoo/BOJ/15903/sol.py
+++ b/minwoo/BOJ/15903/sol.py
@@ -1,0 +1,13 @@
+import sys
+import heapq
+sys.stdin = open('input.txt', 'r')
+
+N, M = map(int, input().split())
+hq = []
+for i in list(map(int, input().split())):
+    heapq.heappush(hq, i)
+for i in range(M):
+    x, y = heapq.heappop(hq), heapq.heappop(hq)
+    heapq.heappush(hq, x + y)
+    heapq.heappush(hq, x + y)
+print(sum(hq))


### PR DESCRIPTION
### 문제 설명
- 문제 : [BOJ 15903 카드 합체 놀이](https://www.acmicpc.net/problem/15903)
- 플랫폼: 백준
- 난이도 : Silver 1
- 시간 : Python 56ms / C++ 0ms
- 메모리 : Python 35508KB / C++ 2160KB

### 코드
<details>
<summary>Python</summary>

```py
import sys
import heapq

N, M = map(int, input().split())
hq = []
for i in list(map(int, input().split())):
    heapq.heappush(hq, i)
for i in range(M):
    x, y = heapq.heappop(hq), heapq.heappop(hq)
    heapq.heappush(hq, x + y)
    heapq.heappush(hq, x + y)
print(sum(hq))
```

</details>

<details>
<summary>C++</summary>

```cpp
#include <iostream>
#include <queue>
using namespace std;

int main() {
	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);

	int N, M;
    priority_queue<long long int, vector<long long int>, greater<long long int>> pq;

	cin >> N >> M;
	int num;
	for (int i = 0; i < N; i++) {
		cin >> num;
		pq.push(num);
	}
	for (int i = 0; i < M; i++) {
		long long int x = pq.top(); 
		pq.pop();
		long long int y = pq.top(); 
		pq.pop();
		pq.push(x+y); pq.push(x+y);
	}
	long long int result = 0;
	while (!pq.empty()) {
		result += pq.top();
		pq.pop();
	}
	cout << result << "\n";
	return 0;
}
```

</details>

### 풀이 방식
- 배열 정렬하는게 오래 걸린다는 생각 -> 최소 힙으로 logN까지 떨굴 수 있다는 사실
- pop 두번 해서 x, y 선택, 두 합을 다시 push하고 마지막에 전체 더해서 출력
- cpp는 자료형이 틀려서 틀리게 출력된듯(처음 input이 백만(1,000,000)일 경우 N이 1,000이고 13N번만큼의 합이 일어나 130억, 하지만 int형은 약 21이므로 초과

---
* PR 제목은 커밋 메시지와 통일합니다.