### PR TITLE
[Solve] :PC방 요금 문제 해결

### DIFF
--- a/JJangDongHyeon/BOJ/9080/sol.py
+++ b/JJangDongHyeon/BOJ/9080/sol.py
@@ -1,0 +1,38 @@
+import sys
+sys.stdin = open('input.txt')
+
+def convert_time(h, m):
+    return (h + 2) % 24, m
+
+def simulate(h, m, remain):
+    total_fee = 0
+
+    while remain > 0:
+        # 현재 시각 → 분으로 변환
+        minutes = h * 60 + m
+
+        # 00:00 ~ 04:59 사이 && 5시간 이상이면 정액권 사용
+        if h <= 4 and remain > 300:
+            used = 600 - minutes  # 10:00까지 남은 시간
+            remain -= used
+            h, m = 10, 0
+            total_fee += 5000
+
+        else:
+            remain -= 60
+            total_fee += 1000
+            h = (h + 1) % 24  # 1시간 경과
+            # m은 항상 0 유지 (정확히 한 시간 단위로 처리하므로)
+
+    return total_fee
+
+# 입력 처리
+T = int(input())
+for _ in range(T):
+    time_str, D = input().split()
+    h, m = map(int, time_str.split(":"))
+    D = int(D)
+
+
+    h, m = convert_time(h, m)
+    print(simulate(h, m, D))


### PR DESCRIPTION
### 문제 설명

- 문제 : PC방 요금
- 플랫폼: 백준
- 난이도 : 골드4
- 시간 : 36ms
- 메모리 : 32412kb

### 코드

```
import sys
sys.stdin = open('input.txt')

def convert_time(h, m):
    return (h + 2) % 24, m

def simulate(h, m, remain):
    total_fee = 0

    while remain > 0:
        # 현재 시각 → 분으로 변환
        minutes = h * 60 + m

        # 00:00 ~ 04:59 사이 && 5시간 이상이면 정액권 사용
        if h <= 4 and remain > 300:
            used = 600 - minutes  # 10:00까지 남은 시간
            remain -= used
            h, m = 10, 0
            total_fee += 5000

        else:
            remain -= 60
            total_fee += 1000
            h = (h + 1) % 24  # 1시간 경과
            # m은 항상 0 유지 (정확히 한 시간 단위로 처리하므로)

    return total_fee

# 입력 처리
T = int(input())
for _ in range(T):
    time_str, D = input().split()
    h, m = map(int, time_str.split(":"))
    D = int(D)


    h, m = convert_time(h, m)
    print(simulate(h, m, D))
```

### 풀이 방식

---
뭔가...이런 알고리즘 같은 알고리즘 문제가 좀 어렵네요;;
22:00 ~ 08:00 으로 심야 시간을 계산하면 나중에 좀 복잡해져서, 00:00 ~ 10:00 시간까지 심야 시간으로 임의로 바꿔서 계산을 합니다.
그리고 사용자의 이용 시작 시간을 전부 분으로 바꿔서 심야 시간인지 확인하고, 심야 시간은 10시까지지만, 정액권이 이득이 되는 시간대는 00:00~04:59뿐이니까 체크합니다. 
- PR 제목은 커밋 메시지와 통일합니다.
