### PR TITLE
[Solve] : [BOJ] 28282 운명 - 문제해결

### DIFF
--- a/sunwoo/BOJ/28282/sol.py
+++ b/sunwoo/BOJ/28282/sol.py
@@ -1,0 +1,38 @@
+# x : 한 바구니에 있는 양말 개수 / k : 양말의 색 종류 수
+x, k = map(int, input().split())
+# 총 2x개의 양말 색 정보 입력받기 (앞의 x개는 왼쪽, 뒤의 x개는 오른쪽)
+sock_colors = list(map(int, input().split()))
+
+# 왼쪽 양말: 0 ~ x-1 / 오른쪽 양말: x ~ 2x-1
+left_socks = sock_colors[:x]
+right_socks = sock_colors[x:]
+
+# 왼쪽, 오른쪽 같은 양말 색 갯수 저장할 딕셔너리
+left_cnt = {}
+right_cnt = {}
+
+# 왼쪽 양말 색 개수 세기
+for color in left_socks:
+    if color not in left_cnt:
+        left_cnt[color] = 0
+    left_cnt[color] += 1
+
+# 오른쪽 양말 색 개수 세기
+for color in right_socks:
+    if color not in right_cnt:
+        right_cnt[color] = 0
+    right_cnt[color] += 1
+
+# 모든 경우의 수
+all_cases = x * x
+
+# 같은 쌍의 수를 누적할 변수
+same_pair = 0
+for num in range(1, k+1):
+    # get()메서드로 왼쪽 양말 색 num의 개수 x 오른쪽 양말 색 num의 개수를 가지고 와서
+    # wame_pair 변수에 누적한다
+    # 만약 num이 왼쪽 양말 or 오른쪽 양말 딕셔너리에 없으면 0 반환
+    same_pair += left_cnt.get(num, 0) * right_cnt.get(num, 0)
+
+# 결과 출력
+print(all_cases - same_pair)


### PR DESCRIPTION
### 문제 설명

- 문제 : 28282번: 운명
- 플랫폼: 백준 
- 난이도 : 실버 5
- 시간 : 132ms
- 메모리 : 53288kb

### 코드

```python
# x : 한 바구니에 있는 양말 개수 / k : 양말의 색 종류 수
x, k = map(int, input().split())
# 총 2x개의 양말 색 정보 입력받기 (앞의 x개는 왼쪽, 뒤의 x개는 오른쪽)
sock_colors = list(map(int, input().split()))

# 왼쪽 양말: 0 ~ x-1 / 오른쪽 양말: x ~ 2x-1
left_socks = sock_colors[:x]
right_socks = sock_colors[x:]

# 왼쪽, 오른쪽 같은 양말 색 갯수 저장할 딕셔너리
left_cnt = {}
right_cnt = {}

# 왼쪽 양말 색 개수 세기
for color in left_socks:
    if color not in left_cnt:
        left_cnt[color] = 0
    left_cnt[color] += 1

# 오른쪽 양말 색 개수 세기
for color in right_socks:
    if color not in right_cnt:
        right_cnt[color] = 0
    right_cnt[color] += 1

# 모든 경우의 수
all_cases = x * x

# 같은 쌍의 수를 누적할 변수
same_pair = 0
for num in range(1, k+1):
    # get()메서드로 왼쪽 양말 색 num의 개수 x 오른쪽 양말 색 num의 개수를 가지고 와서
    # wame_pair 변수에 누적한다
    # 만약 num이 왼쪽 양말 or 오른쪽 양말 딕셔너리에 없으면 0 반환
    same_pair += left_cnt.get(num, 0) * right_cnt.get(num, 0)

# 결과 출력
print(all_cases - same_pair)

```

### 풀이 방식

- 처음에는 2차원 돌려서 하나하나씩 비교했는데 시간초과 냠냠이 해버렸 음..제한 보니 납득
- 이 문제는 "서로 다른 색 양말 쌍"을 세는 거라서 모든 경우의 수에서 같은 색 쌍만 빼주면 됌
- `전체 쌍 수 - 같은 색 쌍 수`
---
- PR 제목은 커밋 메시지와 통일합니다.
