### PR TITLE
[Solve] : [BOJ] 15655 N과 M (6) - 문제 해결

### DIFF
--- a/minwoo/BOJ/15655/sol.cpp
+++ b/minwoo/BOJ/15655/sol.cpp
@@ -1,0 +1,40 @@
+#include <algorithm>
+#include <iostream>
+#include <vector>
+using namespace std;
+
+/*
+n개의 자연수와 자연수 m
+n개의 자연수 중에서 m개를 고른 수열
+고른 수열은 오름차순
+중복되는 수열을 여러 번 출력하면 안됨
+*/
+int n, m;
+vector<int> v;
+
+void dfs(int depth, int idx, vector<int>& r) {
+	if (depth == m) {
+		for (int i = 0; i < m; ++i)
+			cout << r[i] << (i == m - 1 ? "\n" : " ");
+		return;
+	}
+	for (int i = idx; i < n; ++i) {
+		r.push_back(v[i]);
+		dfs(depth + 1, i + 1, r);
+		r.pop_back();
+	}
+	return;
+}
+
+int main() {
+	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+
+	cin >> n >> m;
+	v.resize(n);
+	for (int i = 0; i < n; ++i)
+		cin >> v[i];
+	sort(v.begin(), v.end());
+	vector<int> empty;
+	dfs(0, 0, empty);
+	return 0;
+}


### PR DESCRIPTION
### 문제 설명

- 문제 : [N과 M (6)](https://www.acmicpc.net/problem/15655)
- 플랫폼: 백준
- 난이도 : S3
- 시간 : 0ms
- 메모리 : 2024KB

### 코드

```cpp
#include <algorithm>
#include <iostream>
#include <vector>
using namespace std;

int n, m;
vector<int> v;

void dfs(int depth, int idx, vector<int> r) {
	if (depth == m) {
		for (int i = 0; i < m; ++i)
			cout << r[i] << (i == m - 1 ? "\n" : " ");
		return;
	}
	for (int i = idx; i < n; ++i) {
		r.push_back(v[i]);
		dfs(depth + 1, i + 1, r);
		r.pop_back();
	}
	return;
}

int main() {
	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);

	cin >> n >> m;
	v.resize(n);
	for (int i = 0; i < n; ++i)
		cin >> v[i];
	sort(v.begin(), v.end());
	vector<int> empty;
	dfs(0, 0, empty);
	return 0;
}
```

### 풀이 방식
- dfs 함수 매개변수에 있는 `vector<int> r`에 주소 참조형식을 넣든 복사를 하든 메모리 차이가 없어서 확인해본 결과
---
- 📌 이유 1: 재귀 깊이가 얕다 (m의 범위 제한)
dfs는 최대 m번까지 재귀 호출되며, r의 크기도 최대 m입니다.
즉, vector<int>의 복사가 이뤄진다 해도 매번 작은 크기의 벡터만 복사됩니다.

예시:
m = 3이면, r 크기: 0 → 1 → 2 → 3

vector<int> 내부 복사는 평균 O(m) → 실제로는 수백 번 반복해도 미미

- 📌 이유 2: std::vector의 복사 최적화
C++ 표준 라이브러리의 vector는 내부적으로 복사 연산자가 최적화되어 있어, 작은 크기의 벡터 복사 성능이 매우 좋습니다.

즉, r.push_back()한 후의 dfs(...) 호출에서 r이 값으로 넘어간다 해도 그 비용이 크지 않음.

- 📌 이유 3: 컴파일러의 RVO (Return Value Optimization) 또는 복사 생략 최적화
GCC, Clang, MSVC 같은 현대 컴파일러는 **복사 자체를 생략하는 최적화(RVO, NRVO)**를 자주 수행합니다. 특히, 로컬 스코프에서 임시 객체만 넘길 때 이런 최적화가 잘 적용됩니다.
(출처: GPT)
---

- PR 제목은 커밋 메시지와 통일합니다.
