### PR TITLE
[Solve] : [BOJ] 23082 균형 삼진법 - 문제 해결

### DIFF
--- a/minwoo/BOJ/23082/sol.cpp
+++ b/minwoo/BOJ/23082/sol.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <string>
+using namespace std;
+
+string solve(int n) {
+	if (n == 0) return "0";
+
+	string res = "";
+	while (n != 0) {
+		int x = n % 3;
+		n /= 3;
+		if (x == 2 || x == -1) {
+			res = 'T' + res;
+			if (x >= 0) n++;
+		}
+		else if (x == -2 || x == 1) {
+			res = '1' + res;
+			if (x < 0) n--;
+		}
+		else {
+			res = '0' + res;
+		}
+	}
+	return res;
+}
+
+int main() {
+	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+	FILE* fp;
+	freopen_s(&fp, "input.txt", "r", stdin);
+	int n;
+	cin >> n;
+	cout << solve(n) << "\n";
+
+	return 0;
+}


### PR DESCRIPTION
### 문제 설명

- 문제 : [균형 삼진법](https://www.acmicpc.net/problem/23082)
- 플랫폼: 백준 / 프로그래머스 / SWEA 등
- 난이도 : 실버1
- 시간 : 0ms
- 메모리 : 2020KB

### 코드

```cpp
#include <iostream>
#include <string>
using namespace std;

string solve(int n) {
	if (n == 0) return "0";

	string res = "";
	while (n != 0) {
		int x = n % 3;
		n /= 3;
		if (x == 2 || x == -1) {
			res = 'T' + res;
			if (x >= 0) n++;
		}
		else if (x == -2 || x == 1) {
			res = '1' + res;
			if (x < 0) n--;
		}
		else {
			res = '0' + res;
		}
	}
	return res;
}

int main() {
	ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
	int n;
	cin >> n;
	cout << solve(n) << "\n";

	return 0;
}
```

### 풀이 방식
- 규칙 : 10진수에서 자리가 바뀌는 시점은 9에서 1을 더한 순간입니다. 그 순간에 이후를 표현할 수 있는 방법이 없기 때문입니다. 마찬가지로 2진수에서 1 이상을 표현할 수 없기 때문에 자리가 바뀌는 겁니다.
- 3진수에서 8은 이렇게 표현할 수 있습니다. `22` 그 이유는 1의 자리는 그대로 1을 나타냅니다. 두번째 자리는 3을 나타냅니다.
- `2 * (3 ^ 1) + 2 * (3 ^ 2)`이런 수식으로도 표현 가능합니다.
- 문제에서는 2가 존재할 수 없습니다. 2가 되는 순간 자리가 바뀌게 되고, 해당 자리는 -1로 표현을 대체하게 됩니다.
- 따라서 몫과 나머지에 따라 추가되는 숫자가 달라지게 되는 것이죠.
- 자리가 올라가는 조건이 보이시나요? -2와 2가 되는 순간 자리가 바뀐다고 판단하는거죠, -2는 자리올림하고 1로 바뀌며 2는 자리올림 이후에 T로 바뀌기 때문에 위 조건이 성립하게 됩니다.
---

- PR 제목은 커밋 메시지와 통일합니다.
