### PR TITLE
[Solved] : BOJ/14728 벼락치기 문제 해결

### DIFF
--- a/Comet/BOJ/14728/소스.cpp
+++ b/Comet/BOJ/14728/소스.cpp
@@ -1,0 +1,28 @@
+using namespace std;
+#include <iostream>
+#include <algorithm>
+int solve() {
+	int num, limit; cin >> num >> limit;
+	int score[100], times[100];
+	int dp[10001] = { 0 };
+	int k, s;
+	for (int i = 0; i < num; ++i) {
+		cin >> k >> s;
+		score[i] = s;
+		times[i] = k;
+	}
+	for (int i = 0; i < num; ++i) {
+		for (int j = limit; j >= times[i]; --j) {
+			dp[j] = max(dp[j], dp[j - times[i]] + score[i]);
+		}
+	}
+	return dp[limit];
+}
+
+
+int main() {
+	int result = solve();
+	cout << result << '\n';
+	return 0;
+}
+


### PR DESCRIPTION
### 문제 설명

- 문제 : [벼락치기](https://www.acmicpc.net/problem/14728)
- 플랫폼: 백준
- 난이도 : 골드 5
- 시간 : 0ms
- 메모리 : 2020kb

### 코드

```cpp
using namespace std;
#include <iostream>
#include <algorithm>
int solve() {
	int num, limit; cin >> num >> limit;
	int score[100], times[100];
	int dp[10001] = { 0 };
	int k, s;
	for (int i = 0; i < num; ++i) {
		cin >> k >> s;
		score[i] = s;
		times[i] = k;
	}
	for (int i = 0; i < num; ++i) {
		for (int j = limit; j >= times[i]; --j) {
			dp[j] = max(dp[j], dp[j - times[i]] + score[i]);
		}
	}
	return dp[limit];
}


int main() {
	int result = solve();
	cout << result << '\n';
	return 0;
}

```

### 풀이 방식
* 이 문제는 아주 유명한 dp 문제인 냅색 (배낭) 문제와 같다.
* 2중  for 문으로 문제를 해결한다.
* 첫 for 문은 100개의 과목들을 하나씩 순회한다.
* 두번째 for 문은 최대 시간 ~ 현재 과목의 공부 소요시간 까지 역순으로 탐색한다.
* 현재 dp값( j 시간을 공부했을 때 현재까지 최대 취득 점수 값) 과 현재 공부를 한다는 가정하에 현재시간까지 얻을 수 있는 최대 점수   (dp[  j - 소요시간 ]) 을 비교하여 더 점수를 많이 취득할 수 있는 것으로 갱신.
* 역순으로 탐색하는 이유는 중복적으로 갱신하는 경우가 생기기 때문에 즉, dp 갱신에 있어서 같은 공부를 2번 이상 수행하는 것을 막기 위해서
---

- PR 제목은 커밋 메시지와 통일합니다.
