### PR TITLE
[Solve]: [BOJ] 2668 숫자고르기 - 문제해결

### DIFF
--- a/sangGyenog/BOJ/2668/sol.py
+++ b/sangGyenog/BOJ/2668/sol.py
@@ -1,0 +1,62 @@
+"""02:54
+세로 두 줄, 가로 N개 칸으로 이루어진 표
+첫째 줄 각 칸은 1-N이 순서대로 들어있음
+둘째 줄은 각 칸은 1이상 N이하인 정수가 들어있다
+
+첫째 줄에서 숫자를 적절히 뽑으면 뽑힌 정수들이 이루는 집합과
+뽑힌 정수들의 바로 밑의 둘째 줄에 들어있는 정수들이 이루는 집합이 일치
+
+이 조건을 만족하는 정수를 최대로 많이 뽑는 방법을 출력
+
+입력
+N의 개수
+N줄에 걸쳐 둘째줄 숫자가 주어짐
+
+출력
+가장 많이 뽑은 정수 개수
+정수 오름차순 한줄에 한 개씩
+"""
+import sys
+sys.stdin = open("2668.txt")
+
+def search(start, now, path):
+    # 방문처리
+    visited[now] = 1
+    path.append(now)
+    next = second[now] # 탐색중인 숫자의 연결된 둘째줄 정수
+
+    # 방문한적이 없으면 재귀
+    if not visited[next]:
+        search(start, next, path)
+    elif next == start: # 사이클이 형성되면 결과값에 추가
+        rst.append(path[:])
+
+    # 백트래킹
+    visited[now] = 0
+    path.pop()
+
+N = int(input())
+first = [i for i in range(0, N+1)]
+second = [0]
+visited = [0 for _ in range(N+1)] # 방문여부
+
+# 둘째줄 입력
+for _ in range(N):
+    second.append(int(input()))
+
+rst = []
+# dfs로 조건에 맞는 수찾기
+for i in range(1, N+1):
+    search(i, i, [])
+
+# 결과 값 중복제거
+rst2 = set()
+for i in rst:
+    for j in i:
+        rst2.add(j)
+
+rst2 = sorted(rst2)
+# 출력
+print(len(rst2))
+for i in rst2:
+    print(i)


### PR DESCRIPTION
### 문제 설명

- 문제 : [숫자고르기](https://www.acmicpc.net/problem/2668)
- 플랫폼: 백준
- 난이도 : 골드 5
- 시간 : 36ms
- 메모리 : 32412KB

### 코드

```py
"""02:54
세로 두 줄, 가로 N개 칸으로 이루어진 표
첫째 줄 각 칸은 1-N이 순서대로 들어있음
둘째 줄은 각 칸은 1이상 N이하인 정수가 들어있다

첫째 줄에서 숫자를 적절히 뽑으면 뽑힌 정수들이 이루는 집합과
뽑힌 정수들의 바로 밑의 둘째 줄에 들어있는 정수들이 이루는 집합이 일치

이 조건을 만족하는 정수를 최대로 많이 뽑는 방법을 출력

입력
N의 개수
N줄에 걸쳐 둘째줄 숫자가 주어짐

출력
가장 많이 뽑은 정수 개수
정수 오름차순 한줄에 한 개씩
"""
import sys
sys.stdin = open("2668.txt")

def search(start, now, path):
    # 방문처리
    visited[now] = 1
    path.append(now)
    next = second[now] # 탐색중인 숫자의 연결된 둘째줄 정수

    # 방문한적이 없으면 재귀
    if not visited[next]:
        search(start, next, path)
    elif next == start: # 사이클이 형성되면 결과값에 추가
        rst.append(path[:])

    # 백트래킹
    visited[now] = 0
    path.pop()

N = int(input())
first = [i for i in range(0, N+1)]
second = [0]
visited = [0 for _ in range(N+1)] # 방문여부

# 둘째줄 입력
for _ in range(N):
    second.append(int(input()))

rst = []
# dfs로 조건에 맞는 수찾기
for i in range(1, N+1):
    search(i, i, [])

# 결과 값 중복제거
rst2 = set()
for i in rst:
    for j in i:
        rst2.add(j)

rst2 = sorted(rst2)
# 출력
print(len(rst2))
for i in rst2:
    print(i)
```

### 풀이 방식
숫자로 이루어진 두 리스트라 딕셔너리를 이용하면 가장 빠르게 탐색할 수 있다고 생각했다. 하지만 처음 구현은 (1, 2) → (2, 1) 또는 같은 수로 이루어진 부분만 찾았다. 다른 입력을 생각해보니 조건에 맞는 리스트 결과가 같아야 하는 부분을 놓쳤었다. 조합문제로 접근해 dfs를 이용했다. 조금 독특한 부분은 첫번째와 두번째 모두 각 인덱스 숫자를 같이 가지고 가면서 (1, 2) - (2, 3) - (3, 1)이런식으로 한 사이클을 모두 찾는 방식을 사용해야 했다. 가지치기를 위해 방문처리를 이용했고, 백트래킹을 이용해 여러 조합을 고려해야했다. 마지막 결과값들의 모임에서 정렬후 하나씩 출력해주었다.
