### PR TITLE
[Solved] : BOJ/2014 소수의 곱 문제 해결

### DIFF
--- a/Comet/BOJ/2014/소스.cpp
+++ b/Comet/BOJ/2014/소스.cpp
@@ -1,0 +1,51 @@
+using namespace std;
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <climits>
+#include <unordered_set>
+#include <algorithm>
+long long num_prime, tar;
+
+
+struct compare
+{
+	bool operator ()(const long long& a, const long long& b) {
+		return a > b;
+	}
+};
+vector<long long> primes;
+priority_queue<long long, vector<long long>, compare> que;
+unordered_set<long long> sett;
+int main() {
+	int input;
+	cin >> num_prime >> tar;
+	for (int i = 0; i < num_prime; ++i) {
+		cin >> input;
+		primes.push_back(input);
+		que.push(input);
+		sett.insert(input);
+	}
+	long long cnt = 0;
+	long long cur;
+	long long max_val = primes[num_prime - 1];
+	while (cnt < tar)
+	{	
+		
+		cur = que.top(); que.pop();
+		//cout << cur << '\n';
+		++cnt;
+		for (long long& num : primes) {
+			long long new_val = num * cur;
+			if (new_val >= INT_MAX) continue;
+			if (que.size() >= tar && new_val >= max_val) continue;
+			if (sett.find(new_val) != sett.end()) continue;
+			sett.insert(new_val);
+			que.push(new_val);
+			max_val = max(max_val, new_val);
+		}
+	}
+	cout << cur << '\n';
+
+	return 0;
+}


### PR DESCRIPTION
### 문제 설명

- 문제 : [소수의 곱](https://www.acmicpc.net/problem/2014)
- 플랫폼: 백준
- 난이도 : 골드 1
- 시간 : 76ms
- 메모리 :13564kb

### 코드

```cpp
using namespace std;
#include <iostream>
#include <vector>
#include <queue>
#include <climits>
#include <unordered_set>
#include <algorithm>
long long num_prime, tar;


struct compare
{
	bool operator ()(const long long& a, const long long& b) {
		return a > b;
	}
};
vector<long long> primes;
priority_queue<long long, vector<long long>, compare> que;
unordered_set<long long> sett;
int main() {
	int input;
	cin >> num_prime >> tar;
	for (int i = 0; i < num_prime; ++i) {
		cin >> input;
		primes.push_back(input);
		que.push(input);
		sett.insert(input);
	}
	long long cnt = 0;
	long long cur;
	long long max_val = primes[num_prime - 1];
	while (cnt < tar)
	{	

		cur = que.top(); que.pop();
		//cout << cur << '\n';
		++cnt;
		for (long long& num : primes) {
			long long new_val = num * cur;
			if (new_val >= INT_MAX) continue;
			if (que.size() >= tar && new_val >= max_val) continue;
			if (sett.find(new_val) != sett.end()) continue;
			sett.insert(new_val);
			que.push(new_val);
			max_val = max(max_val, new_val);
		}
	}
	cout << cur << '\n';

	return 0;
}
```

### 풀이 방식
* 아 커밋메세지 안썼다.
* set을 통해 중복을 확인하며 우선순위 큐에 집어넣어 하나씩 빼낸 다음, 각 소수와 곱한 값을 집어넣기를 반복한다.
* 단, 램 제한이 빡빡해서 큐에 들어있는 값의 양이 목표 순번보다 크면서 큐의 최댓값보다 현재 집어넣으려는 값이 크면 패스하는 조건을 넣으니 됨.
---

- PR 제목은 커밋 메시지와 통일합니다.
