### PR TITLE
[Solved] : BOJ/1016 제곱 ㄴㄴ수 문제 해결

### DIFF
--- a/Comet/BOJ/1016/소스.cpp
+++ b/Comet/BOJ/1016/소스.cpp
@@ -1,12 +1,12 @@
 using namespace std;
 #include <iostream>
 #include <vector>
-#include <unordered_map>
+
 int main()
 {
 	long long start, end;
 	cin >> start >> end;
-	unordered_map<long long, bool> can;
+	vector<bool> can(end - start + 2, 0);
 	for (long long i = 2; i <= end; ++i) {
 		long long sq = i * i;
 		if (sq > end) break;
@@ -16,12 +16,12 @@ int main()
 		startpoint *= sq;
 
 		for (long long j = startpoint; j <= end; j += sq) {
-			can[j] = 1;
+			can[j - start] = 1;
 		}
 	}
 	long long result = 0;
 	for (long long i = start; i <= end; ++i) {
-		if (can[i] == 0) {
+		if (can[i - start] == 0) {
 			++result;
 		}
 	}


### PR DESCRIPTION
### 문제 설명

- 문제 : [제곱 ㄴㄴ수](https://www.acmicpc.net/problem/1016)
- 플랫폼: 백준
- 난이도 : 골드 1
- 시간 : 16ms
- 메모리 : 2152kb

### 코드

```cpp
using namespace std;
#include <iostream>
#include <vector>

int main()
{
	long long start, end;
	cin >> start >> end;
	vector<bool> can(end - start + 2, 0);
	for (long long i = 2; i <= end; ++i) {
		long long sq = i * i;
		if (sq > end) break;

		long long startpoint = start / sq;
		if (start % sq != 0) startpoint += 1;
		startpoint *= sq;

		for (long long j = startpoint; j <= end; j += sq) {
			can[j - start] = 1;
		}
	}
	long long result = 0;
	for (long long i = start; i <= end; ++i) {
		if (can[i - start] == 0) {
			++result;
		}
	}
	cout << result << '\n';
	return 0;
}

```

### 풀이 방식
* 수의 최대 범위 차는 백만이지만 각 수는 최댓값이 1조에 도달함으로 start 값을 빼줌으로서 불필요한 좌표 압축 진행.
* 아리스토텔레스의 체를 이용해 하나씩 제거. 
* 시작포인트를 start 값보다 큰 수중 가장 작은 제곱수의 배수로 정함.
---

- PR 제목은 커밋 메시지와 통일합니다.
